### PR TITLE
Get sblim-sfcc building

### DIFF
--- a/sblim-sfcc.rb
+++ b/sblim-sfcc.rb
@@ -1,16 +1,15 @@
 require 'formula'
 
 class SblimSfcc < Formula
-  version  "2.2.6a"
+  version  "2.2.7"
   homepage 'https://sourceforge.net/projects/sblim/'
-  url      'http://sourceforge.net/code-snapshots/git/s/sb/sblim/sfcc.git/sblim-sfcc-274829aaad3deaeabe712ae7cf7ef6c877023e0b.zip'
-  sha1     '7f9fbd7a880e85748a017517f8f7ee1cdf55a916'
+  url      'http://downloads.sourceforge.net/project/sblim/sblim-sfcc/sblim-sfcc-2.2.7.tar.bz2'
+  sha1     '487f30a06fe599ca17340d2ecfd3c32644c96c67'
   depends_on :libtool
   depends_on :autoconf
   depends_on :automake
   
   def install
-    system "./autoconfiscate.sh"
     system "./configure","--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
   end


### PR DESCRIPTION
The referenced tarfile for sblim-sfcc isn't available anymore, so I redid it using the latest version 2.2.7.
