### PR TITLE
update to 2.6

### DIFF
--- a/wsmancli.rb
+++ b/wsmancli.rb
@@ -1,7 +1,7 @@
 class Wsmancli < Formula
   homepage 'https://github.com/Openwsman/wsmancli'
-  url 'https://github.com/Openwsman/wsmancli/archive/v2.3.0.tar.gz'
-  sha1 '161288cbc4f5a60a2d683d96ead3a0934a9c5523'
+  url 'https://github.com/Openwsman/wsmancli/archive/v2.6.0.tar.gz'
+  sha1 '128159204ab22b58a67c92827ced67e70cd2e1f2'
 
   depends_on "openwsman"
   depends_on "autoconf"   => :build


### PR DESCRIPTION
upgrade to 2.6. there may still be a separate [issue](https://github.com/Homebrew/homebrew/issues/44047) with the openwsman package not building because of the `wsman-key-value.h` file, but at least we can update this formula to have the latest version of the sourcecode
